### PR TITLE
fix: prevent DatePicker crash when initialDate is out of range

### DIFF
--- a/lib/view/profile/profile_page.dart
+++ b/lib/view/profile/profile_page.dart
@@ -928,12 +928,23 @@ class _StartSemesterSettingItem extends StatelessWidget {
 
   Future<void> _pickStartDate(BuildContext context) async {
     final now = DateTime.now();
-    final initialDate = startDate ?? now;
+
+    DateTime initialDate = startDate ?? now;
+
+    final firstDate = DateTime(now.year - 5);
+    final lastDate = DateTime(now.year + 5, 12, 31);
+
+    if (initialDate.isBefore(firstDate)) {
+        initialDate = firstDate;
+    } else if (initialDate.isAfter(lastDate)) {
+        initialDate = lastDate;
+    }
+
     final pickedDate = await showDatePicker(
-      context: context,
-      initialDate: initialDate,
-      firstDate: DateTime(now.year - 5),
-      lastDate: DateTime(now.year + 5, 12, 31),
+        context: context,
+        initialDate: initialDate,
+        firstDate: firstDate,
+        lastDate: lastDate,
     );
 
     if (pickedDate == null) return;


### PR DESCRIPTION
### Description

修复Issue #1 中提到的问题

修改方案是在`开学日期设置卡片`即`类_StartSemesterSettingItem` 的`_pickStartDate()`函数添加了对initialDate的判断

如果超出范围下限，则设initialDate为下限值；如果超出范围上限，则设initialDate为上限值

Fixes #1