### PR TITLE
feat: 添加'周课表宽度自适应'设置选项，修复每日节数无法设置问题

### DIFF
--- a/android/local.properties
+++ b/android/local.properties
@@ -1,5 +1,5 @@
 sdk.dir=D:\\Android\\Sdk
 flutter.sdk=D:\\Flutter\\flutter
 flutter.buildMode=debug
-flutter.versionName=1.0.2
-flutter.versionCode=3
+flutter.versionName=1.0.3
+flutter.versionCode=4

--- a/lib/bloc/settings/settings_bloc.dart
+++ b/lib/bloc/settings/settings_bloc.dart
@@ -24,7 +24,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<RefreshSettings>(_onRefreshSettings);
     on<UpdateTotalWeeks>(_onUpdateTotalWeeks);
     on<UpdateThemeMode>(_onUpdateThemeMode);
-    on<UpdateShowWeekend>(_onUpdateShowWeekend);
+    on<UpdateWeeklyScheduleDisplay>(_onUpdateWeeklyScheduleDisplay);
     on<UpdateSectionConfig>(_onUpdateSectionConfig);
     on<UpdateSectionTimes>(_onUpdateSectionTimes);
     on<UpdateStartSemesterDate>(_onUpdateStartSemesterDate);
@@ -55,10 +55,6 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     await _settingsDataStore.setThemeMode(event.themeMode);
   }
 
-  Future<void> _onUpdateShowWeekend(UpdateShowWeekend event, Emitter<SettingsState> emit) async {
-    await _settingsDataStore.setShowWeekend(event.showWeekend);
-  }
-
   Future<void> _onUpdateSectionConfig(UpdateSectionConfig event, Emitter<SettingsState> emit) async {
     await _settingsDataStore.setMorningSections(event.morning);
     await _settingsDataStore.setAfternoonSections(event.afternoon);
@@ -73,6 +69,11 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     if (event.date != null) {
       await _settingsDataStore.setStartSemester(event.date!.millisecondsSinceEpoch);
     }
+  }
+
+  Future<void> _onUpdateWeeklyScheduleDisplay(UpdateWeeklyScheduleDisplay event, Emitter<SettingsState> emit) async {
+    await _settingsDataStore.setShowWeekend(event.showWeekend);
+    await _settingsDataStore.setAdaptiveWidth(event.adaptiveWidth);
   }
 
   /// 处理从JSON导入课程事件

--- a/lib/bloc/settings/settings_event.dart
+++ b/lib/bloc/settings/settings_event.dart
@@ -9,12 +9,14 @@ abstract class SettingsEvent extends Equatable {
   List<Object?> get props => [];
 }
 
+/// 刷新设置数据
 class RefreshSettings extends SettingsEvent {
   const RefreshSettings();
   @override
   List<Object?> get props => [];
 }
 
+/// 更新总周数
 class UpdateTotalWeeks extends SettingsEvent {
   final int totalWeeks;
   const UpdateTotalWeeks(this.totalWeeks);
@@ -22,6 +24,7 @@ class UpdateTotalWeeks extends SettingsEvent {
   List<Object?> get props => [totalWeeks];
 }
 
+/// 更新主题模式
 class UpdateThemeMode extends SettingsEvent {
   final ThemeMode themeMode;
   const UpdateThemeMode(this.themeMode);
@@ -29,6 +32,7 @@ class UpdateThemeMode extends SettingsEvent {
   List<Object?> get props => [themeMode];
 }
 
+/// 更新是否显示周末
 class UpdateShowWeekend extends SettingsEvent {
   final bool showWeekend;
   const UpdateShowWeekend(this.showWeekend);
@@ -36,6 +40,7 @@ class UpdateShowWeekend extends SettingsEvent {
   List<Object?> get props => [showWeekend];
 }
 
+/// 更新每日节数设置
 class UpdateSectionConfig extends SettingsEvent {
   final int morning;
   final int afternoon;
@@ -45,6 +50,7 @@ class UpdateSectionConfig extends SettingsEvent {
   List<Object?> get props => [morning, afternoon, evening];
 }
 
+/// 更新每节课的时间设置
 class UpdateSectionTimes extends SettingsEvent {
   final List<SectionTime> sectionTimes;
   const UpdateSectionTimes(this.sectionTimes);
@@ -52,6 +58,7 @@ class UpdateSectionTimes extends SettingsEvent {
   List<Object?> get props => [sectionTimes];
 }
 
+/// 更新开学日期
 class UpdateStartSemesterDate extends SettingsEvent {
   final DateTime? date;
   const UpdateStartSemesterDate(this.date);
@@ -59,6 +66,7 @@ class UpdateStartSemesterDate extends SettingsEvent {
   List<Object?> get props => [date];
 }
 
+/// 导入课程时间设置
 class ImportCourseTimes extends SettingsEvent {
   final ImportData importData;
 
@@ -68,6 +76,7 @@ class ImportCourseTimes extends SettingsEvent {
   List<Object?> get props => [importData];
 }
 
+/// 导出课程时间设置
 class ExportCourseTimes extends SettingsEvent {
   const ExportCourseTimes();
 

--- a/lib/bloc/settings/settings_event.dart
+++ b/lib/bloc/settings/settings_event.dart
@@ -32,14 +32,6 @@ class UpdateThemeMode extends SettingsEvent {
   List<Object?> get props => [themeMode];
 }
 
-/// 更新是否显示周末
-class UpdateShowWeekend extends SettingsEvent {
-  final bool showWeekend;
-  const UpdateShowWeekend(this.showWeekend);
-  @override
-  List<Object?> get props => [showWeekend];
-}
-
 /// 更新每日节数设置
 class UpdateSectionConfig extends SettingsEvent {
   final int morning;
@@ -56,6 +48,21 @@ class UpdateSectionTimes extends SettingsEvent {
   const UpdateSectionTimes(this.sectionTimes);
   @override
   List<Object?> get props => [sectionTimes];
+}
+
+
+/// 更新周课表展示设置（显示周末 + 宽度自适应）
+class UpdateWeeklyScheduleDisplay extends SettingsEvent {
+  final bool showWeekend;
+  final bool adaptiveWidth;
+
+  const UpdateWeeklyScheduleDisplay({
+    required this.showWeekend,
+    required this.adaptiveWidth,
+  });
+
+  @override
+  List<Object?> get props => [showWeekend, adaptiveWidth];
 }
 
 /// 更新开学日期

--- a/lib/model/app_settings.dart
+++ b/lib/model/app_settings.dart
@@ -21,6 +21,8 @@ class AppSettings extends Equatable {
   final int startSemester;
   // 开学时间是否从星期天开始计算
   final bool startWithSunday;
+  // 周课表宽度自适应
+  final bool adaptiveWidth;
 
   const AppSettings({
     this.totalWeeks = 20,
@@ -32,6 +34,7 @@ class AppSettings extends Equatable {
     this.sectionTimes = defaultSectionTimes,
     this.startWithSunday = false,
     this.startSemester = -1,
+    this.adaptiveWidth = true,
   });
 
   /// 每日总节数
@@ -68,6 +71,7 @@ class AppSettings extends Equatable {
     List<SectionTime>? sectionTimes,
     int? startSemester,
     bool? startWithSunday,
+    bool? adaptiveWidth,
   }) {
     return AppSettings(
       totalWeeks: totalWeeks ?? this.totalWeeks,
@@ -79,6 +83,7 @@ class AppSettings extends Equatable {
       sectionTimes: sectionTimes ?? this.sectionTimes,
       startSemester: startSemester ?? this.startSemester,
       startWithSunday: startWithSunday ?? this.startWithSunday,
+      adaptiveWidth: adaptiveWidth ?? this.adaptiveWidth,
     );
   }
 
@@ -93,5 +98,6 @@ class AppSettings extends Equatable {
     sectionTimes,
     startSemester,
     startWithSunday,
+    adaptiveWidth,
   ];
 }

--- a/lib/model/app_settings.dart
+++ b/lib/model/app_settings.dart
@@ -5,8 +5,6 @@ import 'package:schedu/model/section_time.dart';
 class AppSettings extends Equatable {
   // 学期总周数
   final int totalWeeks;
-  // 每天最多节数
-  final int maxSections;
   // 主题模式
   final ThemeMode themeMode;
   // 是否显示周末
@@ -26,7 +24,6 @@ class AppSettings extends Equatable {
 
   const AppSettings({
     this.totalWeeks = 20,
-    this.maxSections = 12,
     this.themeMode = ThemeMode.system,
     this.showWeekend = true,
     this.morningSections = 4,
@@ -36,6 +33,10 @@ class AppSettings extends Equatable {
     this.startWithSunday = false,
     this.startSemester = -1,
   });
+
+  /// 每日总节数
+  int get totalDailySections =>
+      morningSections + afternoonSections + eveningSections;
 
   /// 默认节次列表（与原 `AppSettingsStore._getDefaultSectionTimesList()` 保持一致）
   static const List<SectionTime> defaultSectionTimes = [
@@ -59,7 +60,6 @@ class AppSettings extends Equatable {
 
   AppSettings copyWith({
     int? totalWeeks,
-    int? maxSections,
     ThemeMode? themeMode,
     bool? showWeekend,
     int? morningSections,
@@ -71,7 +71,6 @@ class AppSettings extends Equatable {
   }) {
     return AppSettings(
       totalWeeks: totalWeeks ?? this.totalWeeks,
-      maxSections: maxSections ?? this.maxSections,
       themeMode: themeMode ?? this.themeMode,
       showWeekend: showWeekend ?? this.showWeekend,
       morningSections: morningSections ?? this.morningSections,
@@ -86,7 +85,6 @@ class AppSettings extends Equatable {
   @override
   List<Object?> get props => [
     totalWeeks,
-    maxSections,
     themeMode,
     showWeekend,
     morningSections,

--- a/lib/repository/app_settings_store.dart
+++ b/lib/repository/app_settings_store.dart
@@ -17,6 +17,7 @@ class AppSettingsStore {
   static const String _keySectionTimes = 'section_times';
   static const String _keyStartSemester = 'start_semester';
   static const String _keyStartWithSunday = 'start_with_sunday';
+  static const String _keyAdaptiveWidth = 'adaptive_width';
 
   static AppSettingsStore? _instance;
   static AppSettingsStore get instance => _instance ??= AppSettingsStore._();
@@ -40,7 +41,7 @@ class AppSettingsStore {
           (mode) => mode.name == prefs.getString(_keyThemeMode),
           orElse: () => ThemeMode.system,
         ),
-        showWeekend: prefs.getBool(_keyShowWeekend) ?? false,
+        showWeekend: prefs.getBool(_keyShowWeekend) ?? true,
         morningSections: prefs.getInt(_keyMorningSections) ?? 4,
         afternoonSections: prefs.getInt(_keyAfternoonSections) ?? 4,
         eveningSections: prefs.getInt(_keyEveningSections) ?? 2,
@@ -51,6 +52,7 @@ class AppSettingsStore {
             : AppSettings.defaultSectionTimes,
         startSemester: prefs.getInt(_keyStartSemester) ?? DateTime.now().millisecondsSinceEpoch,
         startWithSunday: prefs.getBool(_keyStartWithSunday) ?? false,
+        adaptiveWidth: prefs.getBool(_keyAdaptiveWidth) ?? true,
       );
       _streamController.add(_data);
     });
@@ -150,6 +152,16 @@ class AppSettingsStore {
       await prefs.setBool(_keyStartWithSunday, startWithSunday);
       _data = _data.copyWith(
         startWithSunday: startWithSunday,
+      );
+    });
+  }
+
+  /// 设置课表宽度自适应
+  Future<void> setAdaptiveWidth(bool width) async {
+    await _update((prefs) async {
+      await prefs.setBool(_keyAdaptiveWidth, width);
+      _data = _data.copyWith(
+        adaptiveWidth: width,
       );
     });
   }

--- a/lib/view/profile/profile_page.dart
+++ b/lib/view/profile/profile_page.dart
@@ -193,7 +193,7 @@ class _ProfilePageState extends State<ProfilePage> {
                 context,
                 icon: Icons.format_list_numbered_outlined,
                 title: '每日节数',
-                subtitle: '当前设置: ${settingsState.appSettings.maxSections}节',
+                subtitle: '当前设置: ${settingsState.appSettings.totalDailySections}节',
                 onTap: () => _showTimePeriodSettingDialog(
                   context,
                   settingsState.appSettings.morningSections,
@@ -210,7 +210,7 @@ class _ProfilePageState extends State<ProfilePage> {
                 onTap: () => _showSectionTimesSettingDialog(
                   context,
                   settingsState.appSettings.sectionTimes,
-                  settingsState.appSettings.maxSections,
+                  settingsState.appSettings.totalDailySections,
                 ),
               ),
 

--- a/lib/view/profile/profile_page.dart
+++ b/lib/view/profile/profile_page.dart
@@ -10,6 +10,7 @@ import 'package:schedu/bloc/settings/settings_bloc.dart';
 import 'package:schedu/bloc/settings/settings_event.dart';
 import 'package:schedu/bloc/settings/settings_state.dart';
 import 'package:schedu/gen/assets.gen.dart';
+import 'package:schedu/model/app_settings.dart';
 import 'package:schedu/model/section_time.dart';
 import 'package:schedu/service/course_import_service.dart';
 
@@ -180,13 +181,13 @@ class _ProfilePageState extends State<ProfilePage> {
                 subtitle: '当前设置: ${settingsState.appSettings.totalWeeks}周',
                 onTap: () => _showTotalWeeksSettingDialog(context, settingsState.appSettings.totalWeeks),
               ),
-              // 周末显示设置
+              // 周课表展示设置（显示周末 + 宽度自适应）
               _buildSettingItem(
                 context,
-                icon: Icons.weekend_outlined,
-                title: '显示周末',
-                subtitle: settingsState.appSettings.showWeekend ? '已开启' : '已关闭',
-                onTap: () => _showWeekendSettingDialog(context, settingsState.appSettings.showWeekend),
+                icon: Icons.grid_view,
+                title: '周课表展示设置',
+                subtitle: _getWeeklyScheduleDisplaySubtitle(settingsState.appSettings),
+                onTap: () => _showWeeklyScheduleDisplayDialog(context, settingsState.appSettings),
               ),
               // 每日节数设置
               _buildSettingItem(
@@ -213,7 +214,6 @@ class _ProfilePageState extends State<ProfilePage> {
                   settingsState.appSettings.totalDailySections,
                 ),
               ),
-
               const SizedBox(height: 24),
 
               // 数据管理分组
@@ -327,6 +327,8 @@ class _ProfilePageState extends State<ProfilePage> {
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
         trailing: Icon(
           Icons.chevron_right,
@@ -386,55 +388,6 @@ class _ProfilePageState extends State<ProfilePage> {
             child: const Text('确定'),
           ),
         ],
-      ),
-    );
-  }
-
-  /// 显示周末设置对话框
-  void _showWeekendSettingDialog(BuildContext context, bool currentShowWeekend) {
-    bool showWeekend = currentShowWeekend;
-    
-    showDialog(
-      context: context,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) => AlertDialog(
-          title: const Text('周末显示设置'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Text('是否在课程表中显示周末？'),
-              const SizedBox(height: 16),
-              SwitchListTile(
-                title: const Text('显示周末'),
-                subtitle: const Text('关闭后课程表只显示周一到周五'),
-                value: showWeekend,
-                onChanged: (value) {
-                  setState(() {
-                    showWeekend = value;
-                  });
-                },
-              ),
-            ],          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('取消'),
-            ),
-            FilledButton(
-              onPressed: () {
-                context.read<SettingsBloc>().add(UpdateShowWeekend(showWeekend));
-                Navigator.of(context).pop();
-                
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(showWeekend ? '已开启周末显示' : '已关闭周末显示'),
-                  ),
-                );
-              },
-              child: const Text('确定'),
-            ),
-          ],
-        ),
       ),
     );
   }
@@ -570,6 +523,63 @@ class _ProfilePageState extends State<ProfilePage> {
         eveningSections: settingsState.appSettings.eveningSections,
         onParseTimeOfDay: _parseTimeOfDay,
         onFormatTimeOfDay: _formatTimeOfDay,
+      ),
+    );
+  }
+
+  String _getWeeklyScheduleDisplaySubtitle(AppSettings appSettings) {
+    final weekendText = appSettings.showWeekend ? '显示周末：已开启' : '显示周末：已关闭';
+    final widthText = appSettings.adaptiveWidth ? '宽度自适应：已开启' : '宽度自适应：已关闭';
+    return '$weekendText · $widthText';
+  }
+
+  void _showWeeklyScheduleDisplayDialog(BuildContext context, AppSettings appSettings) {
+    bool showWeekend = appSettings.showWeekend;
+    bool adaptiveWidth = appSettings.adaptiveWidth;
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: const Text('周课表展示设置'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SwitchListTile(
+                title: const Text('显示周末'),
+                subtitle: const Text('在周视图中显示周六、周日'),
+                value: showWeekend,
+                onChanged: (value) => setState(() => showWeekend = value),
+              ),
+              SwitchListTile(
+                title: const Text('宽度自适应'),
+                subtitle: const Text('占满屏幕宽度，禁用横向滑动'),
+                value: adaptiveWidth,
+                onChanged: (value) => setState(() => adaptiveWidth = value),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final bloc = context.read<SettingsBloc>();
+                bloc.add(UpdateWeeklyScheduleDisplay(
+                  showWeekend: showWeekend,
+                  adaptiveWidth: adaptiveWidth,
+                ));
+                Navigator.of(dialogContext).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('周课表展示设置已保存')),
+                );
+              },
+              child: const Text('确定'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/weekly/weekly_course_page.dart
+++ b/lib/view/weekly/weekly_course_page.dart
@@ -168,6 +168,8 @@ class _WeeklyCoursePageState extends State<WeeklyCoursePage>
     const breakCellHeight = 24.0;
     const headerHeight = 48.0;
 
+    final useAdaptiveWidth = settings.adaptiveWidth;
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final screenWidth = constraints.maxWidth.isFinite
@@ -176,23 +178,33 @@ class _WeeklyCoursePageState extends State<WeeklyCoursePage>
         // 计算可用宽度并确定每日列宽度
         final availableWidth = math.max(screenWidth - sectionColumnWidth, 0.0);
         final rawDayWidth = dayCount > 0 ? availableWidth / dayCount : minDayColumnWidth;
-        final dayColumnWidth = math.min(math.max(rawDayWidth, minDayColumnWidth), maxDayColumnWidth);
+        final dayColumnWidth = useAdaptiveWidth
+            ? rawDayWidth
+            : math.min(math.max(rawDayWidth, minDayColumnWidth), maxDayColumnWidth);
         final contentWidth = sectionColumnWidth + dayColumnWidth * dayCount;
 
-        return SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: SizedBox(
-            width: contentWidth,
-            child: SingleChildScrollView(
-              child: Column(
-                children: [
-                  _buildTableHeader(context, displayDays, weekStart, sectionColumnWidth, dayColumnWidth, headerHeight),
-                  _buildTableContent(context, coursesByDay, dayCount, settings, sectionColumnWidth, dayColumnWidth, sectionCellHeight, breakCellHeight),
-                ],
-              ),
-            ),
-          ),
+        final scheduleColumn = Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildTableHeader(context, displayDays, weekStart, sectionColumnWidth, dayColumnWidth, headerHeight),
+            _buildTableContent(context, coursesByDay, dayCount, settings, sectionColumnWidth, dayColumnWidth, sectionCellHeight, breakCellHeight),
+          ],
         );
+
+        final verticalScroll = SingleChildScrollView(child: scheduleColumn);
+
+        return useAdaptiveWidth
+            ? Container(
+                width: double.infinity,
+                child: verticalScroll,
+              )
+            : SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SizedBox(
+                  width: contentWidth,
+                  child: verticalScroll,
+                ),
+              );
       },
     );
   }

--- a/lib/view/weekly/weekly_course_page.dart
+++ b/lib/view/weekly/weekly_course_page.dart
@@ -296,7 +296,7 @@ class _WeeklyCoursePageState extends State<WeeklyCoursePage>
   /// 构建节次列
   Widget _buildSectionColumn(BuildContext context, AppSettings settings, double sectionWidth, double sectionHeight, double breakHeight) {
     final List<Widget> children = [];
-    for (int section = 1; section <= settings.maxSections; section++) {
+    for (int section = 1; section <= settings.totalDailySections; section++) {
       if (WeeklyScheduleUtils.shouldShowBreakRow(section, settings.morningSections, settings.afternoonSections)) {
         final breakName = WeeklyScheduleUtils.getBreakRowName(section, settings.morningSections, settings.afternoonSections);
         children.add(_buildSectionBreakCell(context, breakName, sectionWidth, breakHeight));
@@ -310,7 +310,7 @@ class _WeeklyCoursePageState extends State<WeeklyCoursePage>
   Widget _buildDayColumn(BuildContext context, int day, List<Course> courses, AppSettings settings, double dayWidth, double sectionHeight, double breakHeight) {
     final List<Widget> children = [];
     int section = 1;
-    while (section <= settings.maxSections) {
+    while (section <= settings.totalDailySections) {
       if (WeeklyScheduleUtils.shouldShowBreakRow(section, settings.morningSections, settings.afternoonSections)) {
         children.add(_buildDayBreakCell(context, dayWidth, breakHeight));
       }
@@ -333,7 +333,7 @@ class _WeeklyCoursePageState extends State<WeeklyCoursePage>
         double height = sectionHeight;
 
         // 计算课程所占行高与跨越节数
-        while (nextSection <= settings.maxSections && course.sections.contains(nextSection)) {
+        while (nextSection <= settings.totalDailySections && course.sections.contains(nextSection)) {
           if (WeeklyScheduleUtils.shouldShowBreakRow(nextSection, settings.morningSections, settings.afternoonSections)) {
             height += breakHeight;
           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+3
+version: 1.0.3+4
 
 environment:
   sdk: ^3.10.3


### PR DESCRIPTION
实现：周课表界面可以在设置中调节不用左右翻动就能看到周末的课程 (#3)
修复：每日节数设置后无效的问题 (#7)

更新版本